### PR TITLE
Extend DSN configuration to support configuration of template name prefix #0000

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
         "issues": "https://github.com/linkorb/herald-client-php/issues"
     },
     "require": {
+        "php": ">=7.0",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "symfony/console": "^2.4|^3.0|^4.0|^5.0|^6.0",
-        "symfony/dotenv": "^3.0|^4.0|^5.0|^6.0"
+        "symfony/console": "^2.4|^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/dotenv": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,15 +7,12 @@ use GuzzleHttp\Client as GuzzleClient;
 
 class Client implements MessageSenderInterface
 {
-    private $apiUrl;
     private $baseUrl;
     private $username;
     private $password;
     private $transportAccount;
     private $templateNamePrefix = '';
     private $toAddressOverride = null;
-    private $account;
-    private $library;
 
     public function __construct(
         $username,
@@ -27,9 +24,6 @@ class Client implements MessageSenderInterface
     ) {
         $this->username = $username;
         $this->password = $password;
-        $this->apiUrl = $apiUrl;
-        $this->account = $account;
-        $this->library = $library;
         if (!$transportAccount) {
             $transportAccount = '-';
         }
@@ -37,7 +31,7 @@ class Client implements MessageSenderInterface
         $this->baseUrl = $apiUrl.'/'.$account.'/'.$library;
     }
 
-    public static function fromDsn($dsn)
+    public static function fromDsn($dsn): Client
     {
         if (!filter_var($dsn, FILTER_VALIDATE_URL)) {
             throw new \RuntimeException('DSN is an invalid URL: '.$dsn);

--- a/src/Client.php
+++ b/src/Client.php
@@ -56,7 +56,18 @@ class Client implements MessageSenderInterface
             $transportAccount = $pathPart[2];
         }
 
-        return new self($username, $password, $apiUrl, $account, $library, $transportAccount);
+        $client = new self($username, $password, $apiUrl, $account, $library, $transportAccount);
+
+        if (!empty($part['query'])) {
+            parse_str($part['query'], $query);
+            foreach ($query as $key => $value) {
+                if ('template_name_prefix' === $key) {
+                    $client->setTemplateNamePrefix($value);
+                }
+            }
+        }
+
+        return $client;
     }
 
     public function send(MessageInterface $message, $skipNamePrefix = false)
@@ -337,7 +348,7 @@ class Client implements MessageSenderInterface
         return $res;
     }
 
-    public function setTemplateNamePrefix($prefix)
+    public function setTemplateNamePrefix(string $prefix): Client
     {
         $this->templateNamePrefix = $prefix;
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -3,10 +3,8 @@
 namespace Herald\Client\Command;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Herald\Client\Client as HeraldClient;
 
 abstract class BaseCommand extends Command

--- a/src/Command/ContactAddCommand.php
+++ b/src/Command/ContactAddCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -27,7 +28,7 @@ class ContactAddCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
@@ -36,5 +37,7 @@ class ContactAddCommand extends BaseCommand
             $input->getArgument('address')
         );
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ContactDeleteCommand.php
+++ b/src/Command/ContactDeleteCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,10 +23,11 @@ class ContactDeleteCommand extends BaseCommand
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
         $res = $c->deleteContact(intval($input->getArgument('contactId')));
         print_r($res);
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ContactPropertiesCommand.php
+++ b/src/Command/ContactPropertiesCommand.php
@@ -4,11 +4,8 @@ namespace Herald\Client\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Client as HeraldClient;
-use Herald\Client\Message;
 
 class ContactPropertiesCommand extends BaseCommand
 {
@@ -26,11 +23,13 @@ class ContactPropertiesCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $res = $c->getContactProperties(intval($input->getArgument('contactId')));
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ContactViewCommand.php
+++ b/src/Command/ContactViewCommand.php
@@ -4,11 +4,8 @@ namespace Herald\Client\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Client as HeraldClient;
-use Herald\Client\Message;
 
 class ContactViewCommand extends BaseCommand
 {
@@ -27,11 +24,13 @@ class ContactViewCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $res = $c->viewContact(intval($input->getArgument('contactId')));
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListConditionsCommand.php
+++ b/src/Command/ListConditionsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,11 +23,13 @@ class ListConditionsCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $res = $c->getListConditions(intval($input->getArgument('listId')));
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListContactsCommand.php
+++ b/src/Command/ListContactsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,11 +23,13 @@ class ListContactsCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $res = $c->getContacts(intval($input->getArgument('listId')));
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/ListListCommand.php
+++ b/src/Command/ListListCommand.php
@@ -2,9 +2,9 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Client as HeraldClient;
 
 class ListListCommand extends BaseCommand
 {
@@ -17,11 +17,13 @@ class ListListCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $contacts = $c->getLists();
         print_r($contacts);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/MessageGetCommand.php
+++ b/src/Command/MessageGetCommand.php
@@ -2,10 +2,10 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Message;
 
 class MessageGetCommand extends BaseCommand
 {
@@ -22,11 +22,13 @@ class MessageGetCommand extends BaseCommand
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
         $messageId = (string) $input->getArgument('messageId');
         $messages = $c->getMessageById($messageId);
         print_r($messages);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/MessageListCommand.php
+++ b/src/Command/MessageListCommand.php
@@ -2,9 +2,9 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Message;
 
 class MessageListCommand extends BaseCommand
 {
@@ -17,10 +17,12 @@ class MessageListCommand extends BaseCommand
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
         $messages = $c->getMessages();
         print_r($messages);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/PropertyAddCommand.php
+++ b/src/Command/PropertyAddCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,7 +33,7 @@ class PropertyAddCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
@@ -42,5 +43,7 @@ class PropertyAddCommand extends BaseCommand
             $input->getArgument('value')
         );
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/PropertyDeleteCommand.php
+++ b/src/Command/PropertyDeleteCommand.php
@@ -4,11 +4,8 @@ namespace Herald\Client\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Client as HeraldClient;
-use Herald\Client\Message;
 
 class PropertyDeleteCommand extends BaseCommand
 {
@@ -26,11 +23,13 @@ class PropertyDeleteCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
         $res = $c->deleteProperty(intval($input->getArgument('propertyId')));
         print_r($res);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/SendCommand.php
+++ b/src/Command/SendCommand.php
@@ -2,6 +2,7 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -41,7 +42,7 @@ class SendCommand extends BaseCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $c = $this->getClient($input);
 
@@ -62,6 +63,8 @@ class SendCommand extends BaseCommand
         } else {
             $output->writeln('<warning>Failed!</warning>');
         }
+
+        return Command::SUCCESS;
     }
 
     private function setDataFromString($dataString, Message $message)

--- a/src/Command/TemplateExistsCommand.php
+++ b/src/Command/TemplateExistsCommand.php
@@ -2,10 +2,10 @@
 
 namespace Herald\Client\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Herald\Client\Message;
 
 class TemplateExistsCommand extends BaseCommand
 {
@@ -23,7 +23,7 @@ class TemplateExistsCommand extends BaseCommand
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $client = $this->getClient($input);
 
@@ -32,5 +32,7 @@ class TemplateExistsCommand extends BaseCommand
         } else {
             $output->writeln('<error>Not found</error>');
         }
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -130,6 +130,8 @@ class Template
         return $this;
     }
 
+    private $subject;
+
     public function getSubject()
     {
         return $this->subject;
@@ -141,6 +143,8 @@ class Template
 
         return $this;
     }
+
+    private $body;
 
     public function getBody()
     {


### PR DESCRIPTION
Makes it easier in downstream projects to instantiate the Client using only DSN, avoiding the need for wrapping classes if the service needs to set a prefix before passing the client along to other services. Also makes it easier to configure service through symfony's services.yaml file.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

<!-- Please indicate if your PR introduces a breaking change -->
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)