### PR TITLE
perf: compatible with php8  #0000

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,7 +100,7 @@ class Client implements MessageSenderInterface
 
         $body = json_decode($res->getBody());
 
-        if ($body && 'OK' == strtoupper($body->code)) {            
+        if ($body && 'OK' == strtoupper($body->code)) {
             return true;
         }
         return false;

--- a/src/Client.php
+++ b/src/Client.php
@@ -100,10 +100,9 @@ class Client implements MessageSenderInterface
 
         $body = json_decode($res->getBody());
 
-        if ('OK' == strtoupper($body->code)) {
+        if ($body && 'OK' == strtoupper($body->code)) {            
             return true;
         }
-
         return false;
     }
 


### PR DESCRIPTION
The root cause: Client::templateExists() does $body->code on null JSON response. In PHP 7 this was a notice (silently returned false). In PHP 8, Symfony

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If this relates to a card, please include a link to the card here. Additionally, please terminate the PR title with `#` and the card number, such as `Fix doomsday bug #1234` -->

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [ ] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
